### PR TITLE
Add support for the "lastmod" front-matter variable

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -10,6 +10,11 @@
       {{ $dateFormat := $.Site.Params.dateFormat | default "Jan 2, 2006" }}
       <strong aria-hidden="true">Publish date: </strong>{{ .PublishDate.Format $dateFormat }}
     </div>
+    {{ if ne .Lastmod .PublishDate }}
+    <div class="date">
+      <strong aria-hidden="true">Last update date: </strong>{{ .Lastmod.Format $dateFormat }}
+    </div>
+    {{ end }}
     {{ with .Params.tags }}
       <div class="tags">
         <strong aria-hidden="true">Tags: </strong>


### PR DESCRIPTION
When a post has a lastmod set (when it is different than the publish date, which the variable is set to by default), display the update date below the publish time.

The reason for this is that I have a few posts where I want to show *both* when a post was created, and when it was last updated, because both are important factors. The update date is only shown if it is explicitly set.