### PR TITLE
First attempt at fixing firefox dark mode

### DIFF
--- a/assets/css/template-styles.css
+++ b/assets/css/template-styles.css
@@ -1024,3 +1024,13 @@ h1 svg {
       background: none;
   }
 }
+
+::-moz-selection { /* Code for Firefox */
+    background: rgba(0,0,0,.8);
+    color: #fefefe;
+}
+  
+::selection {
+  background: rgba(0,0,0,.8);
+  color: #fefefe;
+}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,7 +27,7 @@
   <link rel="stylesheet" type="text/css" href="{{ $styles.Permalink }}">
 
   <style id="inverter" media="none">
-    html { filter: invert(100%) }
+    .intro-and-nav, .main-and-footer { filter: invert(100%) }
     * { background-color: inherit }
     img:not([src*=".svg"]), .colors, iframe, .demo-container { filter: invert(100%) }
   </style>


### PR DESCRIPTION
This PR is in regards to Issue #11, where the dark mode toggle causes the navbar to stop scrolling when the dark mode button is clicked on Firefox. I believe the issue is related to [this StackOverflow post ](https://stackoverflow.com/questions/52937708/css-filter-on-parent-breaks-child-positioning/52937920#52937920) which mentions how applying a filter to the parent breaks child positioning. 

This fix is a little hacky as it mainly just removes the filter from the entire html and instead applies it to the two child classes ("intro-and-nav" and "main-and-footer"), but I think this is a step in the right direction. Please let me know if this fix works on your browsers.

In addition to the Firefox dark mode fix, I also changed the text selection color to better fit the black/white theme. This is a more subjective fix, feel free to remove it if you want.