### PR TITLE
Fix favicon links when using a / in baseURL

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,11 +16,11 @@
     <meta name="description" content="{{ $summary }}">
   {{ end }}
 
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000">
+  <link rel="apple-touch-icon" sizes="180x180" href={{ print .Site.BaseURL "/apple-touch-icon.png" }}> 
+  <link rel="icon" type="image/png" sizes="32x32" href={{ print .Site.BaseURL "/favicon-32x32.png" }}> 
+  <link rel="icon" type="image/png" sizes="16x16" href={{ print .Site.BaseURL "/favicon-16x16.png" }}> 
+  <link rel="manifest" href={{ print .Site.BaseURL "/site.webmanifest" }}> 
+  <link rel="mask-icon" href={{ print .Site.BaseURL "/safari-pinned-tab.svg" }} color="#000000"> 
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="theme-color" content="#ffffff">
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,11 +16,11 @@
     <meta name="description" content="{{ $summary }}">
   {{ end }}
 
-  <link rel="apple-touch-icon" sizes="180x180" href={{ print .Site.BaseURL "/apple-touch-icon.png" }}> 
-  <link rel="icon" type="image/png" sizes="32x32" href={{ print .Site.BaseURL "/favicon-32x32.png" }}> 
-  <link rel="icon" type="image/png" sizes="16x16" href={{ print .Site.BaseURL "/favicon-16x16.png" }}> 
-  <link rel="manifest" href={{ print .Site.BaseURL "/site.webmanifest" }}> 
-  <link rel="mask-icon" href={{ print .Site.BaseURL "/safari-pinned-tab.svg" }} color="#000000"> 
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ "apple-touch-icon.png" | absURL }}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ "favicon-32x32.png" | absURL }}"> 
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ "favicon-16x16.png" | absURL }}"> 
+  <link rel="manifest" href="{{ "site.webmanifest" | absURL }}"> 
+  <link rel="mask-icon" href="{{ "safari-pinned-tab.svg" | absURL }}" color="#000000"> 
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="theme-color" content="#ffffff">
 


### PR DESCRIPTION
I noticed that when baseURL contains a / like 
```
// config.yaml
baseURL: https://example/oopsie
```
(which typically happens when you host your site on GitHub Pages) the favicon links don't work.

I fixed it by prefixing the links with baseURL.