### PR TITLE
disable GitInfo

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -5,7 +5,7 @@ title: Cupper
 theme: cupper-hugo-theme
 googleAnalytics: UA-123456789-1
 disqusShortname: yourdiscussshortname
-enableGitInfo: true
+enableGitInfo: false
 
 taxonomies:
   tag: tags


### PR DESCRIPTION
so that `blogdown::new_site(theme = "zwbetz-gh/cupper-hugo-theme")` would work when using this theme in R and blogdown. #55 