### PR TITLE
🖱️ Fix selection highlight css rules for text generated by cmd shortcode

### DIFF
--- a/assets/css/template-styles.css
+++ b/assets/css/template-styles.css
@@ -169,8 +169,8 @@ code {
     padding-right: 0.25em;
 }
 .cmd code::selection{
-	color: #000;
-	background: #fff;
+    background: #fefefe;
+    color: rgba(0,0,0,.8);
 }
 /* Lists */
 main ul,

--- a/assets/css/template-styles.css
+++ b/assets/css/template-styles.css
@@ -168,7 +168,10 @@ code {
     font-weight: bold;
     padding-right: 0.25em;
 }
-
+.cmd code::selection{
+	color: #000;
+	background: #fff;
+}
 /* Lists */
 main ul,
 main ol {


### PR DESCRIPTION
## 🤔 Which problem are you solving ?
When any text generated by the cmd shortcode is selected, it looks as though nothing is selected.

## 👨‍🔬 What do you think creates this problem ?
The default selection highlight css rules from `assets\css\template-styles.css` are 
```
::-moz-selection { /* Code for Firefox */
    background: rgba(0,0,0,.8);
    color: #fefefe;
}
  
::selection {
  background: rgba(0,0,0,.8);
  color: #fefefe;
}
```
But while selecting any text generated by cmd shortcode, these highlighting rules fail since these are the default styles for the text generated by cmd shortcode. Thus it appears as though, nothing has been selected.
## 🖼️ Can you show the problem  in a screenshot ?
![image](https://user-images.githubusercontent.com/68782815/131317462-496d9db7-ffbb-4ab0-a729-cc602f9262dc.png)
I have selected the full line 👆. But it appears as though, nothing has been selected.

## 🖼️ Can you show the improvement/fix  in a screenshot ?
![image](https://user-images.githubusercontent.com/68782815/131316894-0d0b4e1f-1596-41b3-8f23-88bd2b386ddd.png)
I have selected the full line 👆. The selected text is seen.

## 📝 Can you summarize your fix in 1 line ?
I just inverted the colors so that the selected text is distinguishable.
## 🖥️ Can you share a live demo of site after the fix is implemented ?
Visit [this](https://deploy-preview-59--cupper-hugo-theme.netlify.app/cupper-shortcodes/#cmd) .