### PR TITLE
➕ Add support for markdown within notes & warnings

### DIFF
--- a/exampleSite/content/post/cupper-shortcodes/index.md
+++ b/exampleSite/content/post/cupper-shortcodes/index.md
@@ -21,24 +21,24 @@ Even a happy life cannot be without a measure of darkness, and the word happy wo
 
 ```
 {{</* note */>}}
-This is a note! It's something the reader may like to know about but is supplementary to the main content. Use notes when something may be interesting but not critical.
+This is a note! It's something the reader may like to know about but is supplementary to the main content. Use notes when something may be interesting but not critical. You can also *include* **markdown** stuffs like `code`. 
 {{</* /note */>}}
 ```
 
 {{< note >}}
-This is a note! It's something the reader may like to know about but is supplementary to the main content. Use notes when something may be interesting but not critical.
+This is a note! It's something the reader may like to know about but is supplementary to the main content. Use notes when something may be interesting but not critical. You can also *include* **markdown** stuffs like `code`.
 {{< /note >}}
 
 ## warning note
 
 ```
 {{</* warning */>}}
-This is a warning! It's about something the reader should be careful to do or to avoid doing. Use warnings when something could go wrong.
+This is a warning! It's about something the reader should be careful to do or to avoid doing. Use warnings when something could go wrong. You can also *include* **markdown** stuffs like `code`.
 {{</* /warning */>}}
 ```
 
 {{< warning >}}
-This is a warning! It's about something the reader should be careful to do or to avoid doing. Use warnings when something could go wrong.
+This is a warning! It's about something the reader should be careful to do or to avoid doing. Use warnings when something could go wrong. You can also *include* **markdown** stuffs like `code`.
 {{< /warning >}}
 
 ## cmd

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -3,6 +3,6 @@
     <svg class="sign" aria-hidden="true" viewBox="0 0 41.667306 41.66729" focusable="false">
       <use xlink:href="#info"></use>
     </svg>
-    {{ .Inner }}
+    {{ .Inner | markdownify }}
   </div>
 </aside>

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -3,6 +3,6 @@
     <svg class="sign" aria-hidden="true" viewBox="0 0 48.430474 41.646302" focusable="false">
       <use xlink:href="#warning"></use>
     </svg>
-    {{ .Inner }}
+    {{ .Inner | markdownify }}
   </div>
 </aside>


### PR DESCRIPTION
# 📸 `Screenshot of the problem`
![Screenshot 2021-10-25 142626](https://user-images.githubusercontent.com/68782815/138667903-024bc20b-5ac0-4b74-bdb0-0826b15b9518.jpg)

# 📝` Short description of the fix`
I piped the output of ` .Inner ` to `markdownify`. So, finally we have `{{ .Inner | markdownify }}` which adds support for markdown in these shortcodes.

# 📸 `Screenshot after fix is implemented`
![Screenshot 2021-10-25 142840](https://user-images.githubusercontent.com/68782815/138667936-ca55cfab-22a7-4b41-97e5-b6111cc214e3.jpg)

