### PR TITLE
🔍️ Canonical URLs should be absolute not relative

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   {{ hugo.Generator }}
-  <link rel="canonical" href="{{ .RelPermalink }}">
+  <link rel="canonical" href="{{ .Permalink }}" />
 
   {{ if .IsHome }}
     {{ with .Site.Params.homeMetaContent }}


### PR DESCRIPTION
The Google documentation [here](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls#rel-canonical-link-method) suggests that:

![image](https://user-images.githubusercontent.com/68782815/145751410-f9188979-e2c2-47eb-99eb-47b8cebeb80b.png)

Thus `href="{{ .Permalink }}"` should be used instead of `href="{{ .RelPermalink }}"`.