### PR TITLE
blockquote: apply markdown to author

### DIFF
--- a/layouts/shortcodes/blockquote.html
+++ b/layouts/shortcodes/blockquote.html
@@ -5,7 +5,7 @@
     {{ $quote | markdownify }}
     {{ with (.Get "author") }}
       <br>
-      <span class="author">&mdash; {{ . }}</span>
+      <span class="author">&mdash; {{ . | markdownify }}</span>
     {{ end }}
   </p>
 </blockquote>


### PR DESCRIPTION
This allows formatting in the author field, for example, to add a link.