### PR TITLE
Do not set overscroll-behavior to none for x axis 

### DIFF
--- a/assets/css/template-styles.css
+++ b/assets/css/template-styles.css
@@ -22,7 +22,7 @@ body {
     line-height: 1.5;
     color: #111;
     background-color: #fefefe;
-    overscroll-behavior: none;
+    overscroll-behavior-y: none;
 }
 template {
   display: none !important;


### PR DESCRIPTION
Hello!

(First of all thanks for porting this theme to Hugo, I love it.)

When I was checking out the theme from the demo page (https://cupper-hugo-theme.netlify.app/), I noticed that I can't go back and forward in the history from touch-pad (swipe left/right) on MacOS. Considering this is very natural movement on a webpage, I immediately felt blocked by lack of this. 

After checking the CSS, I noticed that, this is because of disabling `overscroll-behavior` in both X and Y axis. I see the necessity of this in Y axis, as bounce effect doesn't look great on top border line, but I couldn't see any reason to disable it in X axis as overflow should not be possible.

Therefore, I just think it should be a good balance to not disable this behavior in X axis. I tested this in both Firefox and Chrome, and the expected behavior is started working after this fix. Safari wasn't impacted by this at all.

Thanks.